### PR TITLE
Updating to latest version of doorbot

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   , "homebridge"                 : ">=0.4.16"
   }
 , "dependencies"                 :
-  { "doorbot"                    : "3.0.1"
+  { "doorbot"                    : "^3.0.1"
   , "hap-nodejs-community-types" : "https://github.com/homespun/hap-nodejs-community-types.git"
   , "homespun-discovery"         : "0.1.21"
   , "underscore"                 : "1.8.3"


### PR DESCRIPTION
This PR pulls in the latest `doorbot@3.0.1` that includes some authentication fixes and improvements. I also dropped the default retries from `15` to `5`, ideally with the latest authentication improvements the retries aren't even needed :)