### PR TITLE
upgrade to doorbot@5.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   , "homebridge"                 : ">=0.4.16"
   }
 , "dependencies"                 :
-  { "doorbot"                    : "^3.0.1"
+  { "doorbot"                    : "^5.0.0"
   , "hap-nodejs-community-types" : "https://github.com/homespun/hap-nodejs-community-types.git"
   , "homespun-discovery"         : "0.1.26"
   , "underscore"                 : "1.8.3"


### PR DESCRIPTION
@mrose17 - Ring changed their authentication mechanism from basic to oAuth very recently which caused authentication errors. I've pushed up `doorbot@5.0.0` with the new auth code in it.