### PR TITLE
docs: update alternate plugin name

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 Use [this package](https://github.com/dgreif/ring/tree/master/homebridge) instead:
 
-    npm install -g homebridge-ring-alarm
+    npm install -g homebridge-ring
     
 _So long, and thanks for all the fish!_
 


### PR DESCRIPTION
@mrose17 thanks for pointing everyone my way! I learned a lot from you work here and really appreciate your input on my plugin.  I'm happy to take pull requests if you ever see anything I'm doing wrong or could improve.  I had been planning to change the name of the plugin now that it's more than just the alarm.  It's renamed now, sorry I didn't get to it sooner!

One more step you can take to make sure people know to use the new plugin is run `npm deprecate homebridge-platform-ring-video-doorbell "WARNING: This plugin has been deprecated in favor of homebridge-ring"` or whatever message you think works best.